### PR TITLE
Hotfix: limpiar conflicto en README (sección Licencia)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,5 @@ ddev artisan optimize:clear
 
 ## Licencia
 
-<<<<<<< HEAD
 Este proyecto se distribuye bajo la **MIT License**.  
 Consulta el archivo [LICENSE](./LICENSE) para más detalles.
-=======
-Proyecto personal. Sin licencia pública definida por ahora.
->>>>>>> origin/main


### PR DESCRIPTION
Elimina marcadores de merge en README.md y deja la sección de Licencia en formato correcto (MIT).