### PR TITLE
Feature/reading-logs + books UI: rating (5★), grid compacto, portadas nítidas, alerts y layout

### DIFF
--- a/app/Http/Controllers/ReadingLogController.php
+++ b/app/Http/Controllers/ReadingLogController.php
@@ -49,4 +49,15 @@ class ReadingLogController extends Controller
                 ->with('error', 'No se pudo guardar el libro. '.$e->getMessage());
         }
     }
+    
+    // Lista las lecturas guardadas del usuario autenticado
+    public function index()
+    {
+        // Ordenar por lo último guardado
+        $logs = \App\Models\ReadingLog::where('user_id', Auth::id())
+            ->latest()
+            ->paginate(12);
+
+        return view('reading-logs.index', compact('logs'));
+    }
 }

--- a/app/Http/Controllers/ReadingLogController.php
+++ b/app/Http/Controllers/ReadingLogController.php
@@ -9,22 +9,38 @@ use Illuminate\Support\Str;
 
 class ReadingLogController extends Controller
 {
-    // Guarda/actualiza un log de lectura para el usuario autenticado
+    /**
+     * Listado de lecturas del usuario autenticado.
+     */
+    public function index()
+    {
+        // Ordeno por lo último guardado/actualizado
+        $logs = ReadingLog::where('user_id', Auth::id())
+            ->latest()
+            ->paginate(12);
+
+        return view('reading-logs.index', compact('logs'));
+    }
+
+    /**
+     * Guarda/actualiza un log (se llama desde la ficha del libro).
+     * Por ahora solo crea/actualiza con estado 'want' por defecto.
+     */
     public function store(Request $request)
     {
-        // Validación básica del payload que viene desde la vista de detalle
+        // Validación del payload que viene desde la vista de detalle
         $data = $request->validate([
             'volume_id'     => ['required', 'string'],
             'title'         => ['required', 'string'],
             'authors'       => ['nullable', 'string'],
-            'thumbnail_url' => ['nullable', 'string'], // no usar 'url' porque a veces vienen URLs raras con params
+            'thumbnail_url' => ['nullable', 'string'], // a veces vienen URLs raras
             'status'        => ['nullable', 'in:want,reading,read,dropped'],
         ]);
 
         $userId = Auth::id();
         $status = $data['status'] ?? 'want';
 
-        // Truncar a 255 para evitar problemas con VARCHAR
+        // Trunco a 255 para evitar problemas con VARCHAR (comentario en español, estilo “yo”)
         $payload = [
             'title'         => Str::limit($data['title'], 255, ''),
             'authors'       => Str::limit($data['authors'] ?? '', 255, ''),
@@ -33,7 +49,6 @@ class ReadingLogController extends Controller
         ];
 
         try {
-            // Si ya existe, actualizar metadata/estado; si no, lo crea.
             ReadingLog::updateOrCreate(
                 ['user_id' => $userId, 'volume_id' => $data['volume_id']],
                 $payload
@@ -43,21 +58,28 @@ class ReadingLogController extends Controller
                 ->route('books.show', $data['volume_id'])
                 ->with('success', 'Libro guardado en tus lecturas.');
         } catch (\Throwable $e) {
-            // Control básico de errores (DB, carreras, etc.)
             return redirect()
                 ->route('books.show', $data['volume_id'])
-                ->with('error', 'No se pudo guardar el libro. '.$e->getMessage());
+                ->with('error', 'No se pudo guardar el libro. ' . $e->getMessage());
         }
     }
-    
-    // Lista las lecturas guardadas del usuario autenticado
-    public function index()
-    {
-        // Ordenar por lo último guardado
-        $logs = \App\Models\ReadingLog::where('user_id', Auth::id())
-            ->latest()
-            ->paginate(12);
 
-        return view('reading-logs.index', compact('logs'));
+    /**
+     * Actualiza SOLO el estado del log (want/reading/read/dropped) desde el listado.
+     */
+    public function update(Request $request, ReadingLog $readingLog)
+    {
+        // Seguridad: solo el dueño del log puede modificarlo
+        abort_unless($readingLog->user_id === Auth::id(), 403);
+
+        $data = $request->validate([
+            'status' => ['required', 'in:want,reading,read,dropped'],
+        ]);
+
+        $readingLog->update([
+            'status' => $data['status'],
+        ]);
+
+        return back()->with('success', 'Estado actualizado.');
     }
 }

--- a/app/Http/Controllers/ReadingLogController.php
+++ b/app/Http/Controllers/ReadingLogController.php
@@ -82,4 +82,21 @@ class ReadingLogController extends Controller
 
         return back()->with('success', 'Estado actualizado.');
     }
+
+    public function updateRating(\Illuminate\Http\Request $request, \App\Models\ReadingLog $readingLog)
+    {
+        // Solo el dueño del log puede modificarlo
+        abort_unless($readingLog->user_id === \Illuminate\Support\Facades\Auth::id(), 403);
+
+        $data = $request->validate([
+            'rating' => ['nullable', 'integer', 'between:1,10'],
+        ]);
+
+        // Si no viene rating, lo limpiamos (null)
+        $readingLog->update([
+            'rating' => $data['rating'] ?? null,
+        ]);
+
+        return back()->with('success', 'Rating actualizado.');
+    }
 }

--- a/app/Http/Controllers/ReadingLogController.php
+++ b/app/Http/Controllers/ReadingLogController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ReadingLog;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
+
+class ReadingLogController extends Controller
+{
+    // Guarda/actualiza un log de lectura para el usuario autenticado
+    public function store(Request $request)
+    {
+        // Validación básica del payload que viene desde la vista de detalle
+        $data = $request->validate([
+            'volume_id'     => ['required', 'string'],
+            'title'         => ['required', 'string'],
+            'authors'       => ['nullable', 'string'],
+            'thumbnail_url' => ['nullable', 'string'], // no usar 'url' porque a veces vienen URLs raras con params
+            'status'        => ['nullable', 'in:want,reading,read,dropped'],
+        ]);
+
+        $userId = Auth::id();
+        $status = $data['status'] ?? 'want';
+
+        // Truncar a 255 para evitar problemas con VARCHAR
+        $payload = [
+            'title'         => Str::limit($data['title'], 255, ''),
+            'authors'       => Str::limit($data['authors'] ?? '', 255, ''),
+            'thumbnail_url' => Str::limit($data['thumbnail_url'] ?? '', 255, ''),
+            'status'        => $status,
+        ];
+
+        try {
+            // Si ya existe, actualizar metadata/estado; si no, lo crea.
+            ReadingLog::updateOrCreate(
+                ['user_id' => $userId, 'volume_id' => $data['volume_id']],
+                $payload
+            );
+
+            return redirect()
+                ->route('books.show', $data['volume_id'])
+                ->with('success', 'Libro guardado en tus lecturas.');
+        } catch (\Throwable $e) {
+            // Control básico de errores (DB, carreras, etc.)
+            return redirect()
+                ->route('books.show', $data['volume_id'])
+                ->with('error', 'No se pudo guardar el libro. '.$e->getMessage());
+        }
+    }
+}

--- a/app/Models/ReadingLog.php
+++ b/app/Models/ReadingLog.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ReadingLog extends Model
+{
+    // Campos que se pueden asignar en masa
+    protected $fillable = [
+        'user_id',
+        'volume_id',
+        'title',
+        'authors',
+        'thumbnail_url',
+        'status',
+        'rating',
+        'review',
+    ];
+
+    // Casts útiles
+    protected $casts = [
+        'rating' => 'integer',
+    ];
+
+    // Cada log pertenece a un usuario
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/migrations/2025_10_07_182641_create_reading_logs_table.php
+++ b/database/migrations/2025_10_07_182641_create_reading_logs_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    // Tabla para guardar el progreso del usuario con cada libro
+    public function up(): void
+    {
+        Schema::create('reading_logs', function (Blueprint $table) {
+            $table->id();
+
+            // Relación con usuarios (si se borra el usuario, se borran sus logs)
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+
+            // ID del volumen en Google Books (p. ej. "zyTCAlFPjgYC")
+            $table->string('volume_id');
+
+            // Metadatos mínimos para mostrar sin reconsultar la API
+            $table->string('title');
+            $table->string('authors')->nullable();        // "Autor 1, Autor 2"
+            $table->string('thumbnail_url')->nullable();  // URL de portada pequeña
+
+            // Estado de lectura (lo validaremos en app): want|reading|read|dropped
+            $table->string('status', 10)->default('want')->index();
+
+            // Valoración opcional 1–10
+            $table->unsignedTinyInteger('rating')->nullable();
+
+            // Reseña libre opcional
+            $table->text('review')->nullable();
+
+            $table->timestamps();
+
+            // Evitar duplicados del mismo libro para el mismo usuario
+            $table->unique(['user_id', 'volume_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('reading_logs');
+    }
+};

--- a/resources/scss/app.scss
+++ b/resources/scss/app.scss
@@ -1,4 +1,8 @@
-/* ===== Paleta (fácil de cambiar) ===== */
+/* =========================================================
+   ReadOn – estilos base (oscuro), componentes y utilidades
+   ========================================================= */
+
+/* ---------- Variables ---------- */
 :root {
   --bg: #0e0f12;
   --text: #e9eaee;
@@ -7,98 +11,197 @@
   --border: #262a32;
   --shadow: 0 8px 30px rgba(0,0,0,.35);
 
-  --primary: #d1122d;         /* rojo ReadOn */
+  --primary: #d1122d;
   --primary-600: #b10f26;
-  --primary-100: #ffe2e7;     /* para botones outline/hover suaves */
+
+  /* Alerts */
+  --success-bg: #10351d;
+  --success-border: #1e7f34;
+  --success-text: #caf7d6;
+
+  --warning-bg: #3d2a12;
+  --warning-border: #a8670d;
+  --warning-text: #ffd9a6;
 }
 
-/* ===== Reset suave ===== */
+/* ---------- Reset/estructura ---------- */
 * { box-sizing: border-box; }
 html, body { height: 100%; }
+html { scroll-behavior: smooth; }
 body {
   margin: 0;
-  font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial, "Noto Sans";
-  line-height: 1.5;
+  background: var(--bg);
   color: var(--text);
-  background: radial-gradient(1200px 700px at -10% -10%, rgba(209,18,45,.10), transparent 60%) , var(--bg);
+  font: 16px/1.6 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,"Helvetica Neue",Arial,"Apple Color Emoji","Segoe UI Emoji";
 }
+a { color: #7aa2ff; text-decoration: none; }
+a:hover { text-decoration: underline; }
 
-/* ===== Layout ===== */
+/* ---------- Layout ---------- */
 .container {
-  max-width: 980px;
-  padding: 1rem;
+  max-width: 1100px;
   margin: 0 auto;
+  padding: 1.25rem;
 }
+h1, h2, h3 { margin: .25rem 0 1rem; letter-spacing: .2px; }
+h1 { font-size: 2rem; }
+h2 { font-size: 1.5rem; }
+h3 { font-size: 1.125rem; }
 
-/* ===== Header ===== */
-.site-header {
-  background: color-mix(in srgb, var(--card), transparent 30%);
-  border-bottom: 1px solid var(--border);
-  backdrop-filter: blur(6px);
-}
-.site-header .container {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
-.nav { margin-left: auto; display: flex; align-items: center; gap: .75rem; }
-.nav a, .btn-link {
-  color: var(--text);
-  text-decoration: none;
-  padding: .25rem .5rem;
-  opacity: .85;
-}
-.nav a:hover, .btn-link:hover { opacity: 1; }
-.btn-link {
-  border: none; background: none; cursor: pointer; font: inherit;
-  color: var(--text);
-}
-
-/* ===== Card / Hero ===== */
+/* ---------- Card ---------- */
 .card {
   background: var(--card);
   border: 1px solid var(--border);
-  border-radius: 14px;
-  padding: 1.25rem;
+  border-radius: 1rem;
+  overflow: hidden;
   box-shadow: var(--shadow);
 }
-.hero { margin: 2.5rem auto; text-align: center; }
-.hero h1 {
-  font-size: clamp(1.6rem, 2.5vw + 1rem, 2.6rem);
-  margin: 0 0 .5rem;
+.card-thumb {
+  width: 100%;
+  display: flex; align-items: center; justify-content: center;
+  border-bottom: 1px solid var(--border);
 }
-.hero h1 span { color: var(--primary); }
-.hero p { margin: 0 0 1rem; color: var(--muted); }
+.card-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover; /* llena el marco 3:4 */
+}
+.thumb-placeholder {
+  width: 100%; height: 100%;
+  display:flex; align-items:center; justify-content:center;
+  color: var(--muted);
+  font-size: .85rem;
+}
+.card-body { padding: 1rem; }
+.card-body > * + * { margin-top: .6rem; } /* separación vertical suave */
+.title { font-weight: 700; }
+.muted { color: var(--muted); }
+.meta { font-size: .9rem; color: var(--muted); }
+.badge { color: #ffd166; }
 
-/* ===== Botones ===== */
-.btn {
+/* ---------- Inputs & botones ---------- */
+.input {
+  appearance: none;
   display: inline-block;
-  padding: .6rem 1rem;
-  border-radius: 10px;
-  border: 1px solid var(--primary);
-  background: var(--primary);
-  color: #fff;
-  text-decoration: none;
-  font-weight: 600;
-  transition: transform .02s ease, filter .2s ease;
+  width: 100%;
+  border: 1px solid var(--border);
+  background: #0f1116;
+  color: var(--text);
+  border-radius: .6rem;
+  padding: .55rem .7rem;
+  outline: none;
 }
-.btn:hover { filter: brightness(0.98); }
+.input:focus {
+  border-color: #3f4a9c;
+  box-shadow: 0 0 0 3px rgba(63,74,156,.15);
+}
+
+.btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  border: 1px solid transparent;
+  background: var(--primary);
+  color: #fff; padding: .55rem .9rem;
+  border-radius: .7rem; font-weight: 600;
+  cursor: pointer; box-shadow: var(--shadow);
+  transition: transform .05s ease-in, filter .15s ease-in;
+  white-space: nowrap;
+}
+.btn:hover { filter: brightness(1.05); }
 .btn:active { transform: translateY(1px); }
+.btn:disabled { opacity: .6; cursor: not-allowed; }
 
 .btn-outline {
   background: transparent;
-  color: var(--primary);
   border-color: var(--primary);
+  color: var(--primary);
 }
-.btn-outline:hover { background: color-mix(in srgb, var(--primary), transparent 88%); }
-.actions { display: flex; gap: .75rem; justify-content: center; }
+.btn-outline:hover { background: rgba(209,18,45,.12); }
 
-/* ===== Footer ===== */
-.site-footer {
-  border-top: 1px solid var(--border);
-  padding: 1rem 0 2rem;
-  color: var(--muted);
-  background: transparent;
-  margin-top: 3rem;
-  font-size: .95rem;
+/* Fila selector de estado (evita desbordes del botón) */
+.status-row {
+  display: flex; gap: .6rem; align-items: center; flex-wrap: wrap;
 }
+.status-row .input { flex: 1 1 220px; min-width: 0; }
+.status-row .btn   { flex: 0 0 auto; }
+
+/* Acciones del form del rating */
+.form-actions { display:flex; gap:.6rem; flex-wrap: wrap; }
+
+/* ---------- Alerts ---------- */
+.alert {
+  padding: .8rem 1rem;
+  border-radius: .7rem;
+  border: 1px solid var(--border);
+}
+.alert-success {
+  background: var(--success-bg);
+  border-color: var(--success-border);
+  color: var(--success-text);
+}
+.alert-warning {
+  background: var(--warning-bg);
+  border-color: var(--warning-border);
+  color: var(--warning-text);
+}
+
+/* ---------- Stars (5 con medias) ---------- */
+.stars {
+  position: relative;
+  display: inline-block;
+  font-size: 1.5rem;      /* tamaño de estrellas ↑ */
+  line-height: 1;
+}
+.stars__display,
+.stars__fill { letter-spacing: 2px; }
+.stars__display { color: #575a62; }   /* vacías */
+.stars__fill {
+  position: absolute; inset: 0;
+  width: var(--p, 0%);
+  color: #f5c518; overflow: hidden;
+  pointer-events: none;
+}
+.stars__hit {
+  position: absolute; inset: 0;
+  display: grid; grid-template-columns: repeat(10, 1fr);
+}
+.stars__hit button { background: transparent; border: 0; padding: 0; cursor: pointer; }
+
+/* ---------- Paginación (links()) ---------- */
+.pagination { display:flex; gap:.4rem; align-items:center; margin-top:1rem; }
+.pagination a, .pagination span {
+  padding: .35rem .6rem; border-radius: .5rem;
+  border: 1px solid var(--border); background: #0f1116; color: var(--text);
+}
+.pagination .active span {
+  background: var(--primary); border-color: var(--primary); color: #fff;
+}
+
+/* ---------- Utilities (usadas en vistas) ---------- */
+.block { display:block; }
+.flex { display:flex; }
+.items-center { align-items:center; }
+.justify-center { justify-content:center; }
+.gap-2 { gap:.5rem; }
+.mt-2 { margin-top:.5rem; }
+.mt-3 { margin-top:.75rem; }
+.mb-4 { margin-bottom:1rem; }
+
+.grid { display:grid; }
+.grid-cols-1 { grid-template-columns: 1fr; }
+.md\:grid-cols-2 { grid-template-columns: repeat(2,1fr); }
+.lg\:grid-cols-3 { grid-template-columns: repeat(3,1fr); }
+.gap-4 { gap: 1rem; }
+
+.aspect-\[3\/4\] { aspect-ratio: 3 / 4; }
+.bg-gray-100 { background: #15171c; }
+
+.line-clamp-1 { display: -webkit-box; -webkit-line-clamp:1; -webkit-box-orient: vertical; overflow: hidden; }
+.line-clamp-2 { display: -webkit-box; -webkit-line-clamp:2; -webkit-box-orient: vertical; overflow: hidden; }
+
+/* Grid compacto para resultados de búsqueda */
+.results-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+  gap: 1rem;
+}
+.results-grid .card-thumb { aspect-ratio: 3 / 4; }

--- a/resources/views/books/show.blade.php
+++ b/resources/views/books/show.blade.php
@@ -7,13 +7,29 @@
     $v = $book['volumeInfo'] ?? [];
     $title = $v['title'] ?? 'Sin título';
     $authors = isset($v['authors']) ? implode(', ', $v['authors']) : 'Autor desconocido';
-    $thumb = $v['imageLinks']['thumbnail'] ?? null;
     $desc = $v['description'] ?? null;
     $published = $v['publishedDate'] ?? '—';
     $pages = $v['pageCount'] ?? null;
     $cats = isset($v['categories']) ? implode(' · ', $v['categories']) : null;
     $avg = $v['averageRating'] ?? null;
     $volumeId = $book['id'] ?? null;
+
+    // Portada: mejor calidad posible
+    $imgs = $v['imageLinks'] ?? [];
+    $thumb = $imgs['extraLarge'] ?? $imgs['large'] ?? $imgs['medium']
+          ?? $imgs['small'] ?? $imgs['thumbnail'] ?? $imgs['smallThumbnail'] ?? null;
+
+    $upgrade = function (?string $url, int $zoom = 3) {
+        if (!$url) return $url;
+        if (str_contains($url, 'zoom=')) {
+            return preg_replace('/zoom=\d+/', 'zoom='.$zoom, $url);
+        }
+        if (str_contains($url, 'books.google')) {
+            return $url.(str_contains($url, '?') ? '&' : '?').'zoom='.$zoom;
+        }
+        return $url;
+    };
+    $thumb = $upgrade($thumb, 3);
 @endphp
 
 <div class="container">
@@ -25,23 +41,26 @@
         <div class="alert alert-warning mb-4">{{ session('error') }}</div>
     @endif
 
-    <a href="{{ route('books.index') }}" class="text-sm text-blue-600">&larr; Volver a la búsqueda</a>
+    <a href="{{ route('books.index') }}" class="text-sm" style="color:#7aa2ff;">&larr; Volver a la búsqueda</a>
 
     <div class="mt-4 grid grid-cols-1 md:grid-cols-3 gap-6">
+        {{-- Portada grande --}}
         <div>
-            <div class="bg-gray-100 aspect-[3/4] flex items-center justify-center overflow-hidden">
+            <div class="card-thumb aspect-[3/4] bg-gray-100 overflow-hidden">
                 @if($thumb)
-                    <img src="{{ $thumb }}" alt="{{ $title }}" class="w-full h-full object-cover">
+                    <img src="{{ $thumb }}" alt="{{ $title }}">
                 @else
-                    <span class="text-xs text-gray-500">Sin portada</span>
+                    <div class="thumb-placeholder">Sin portada</div>
                 @endif
             </div>
         </div>
+
+        {{-- Info --}}
         <div class="md:col-span-2">
             <h1 class="text-2xl font-bold">{{ $title }}</h1>
-            <p class="text-gray-700">de {{ $authors }}</p>
+            <p class="muted">de {{ $authors }}</p>
 
-            <div class="mt-2 text-sm text-gray-600">
+            <div class="mt-2 text-sm muted">
                 <span>Publicado: {{ $published }}</span>
                 @if($pages) · <span>{{ $pages }} páginas</span>@endif
                 @if($cats) · <span>{{ $cats }}</span>@endif
@@ -57,7 +76,7 @@
                 @auth
                     <form method="POST" action="{{ route('reading-logs.store') }}">
                         @csrf
-                        {{-- Guardar con estado "want" por defecto --}}
+                        {{-- En este micro-paso guardo con estado "want" por defecto --}}
                         <input type="hidden" name="volume_id" value="{{ $volumeId }}">
                         <input type="hidden" name="title" value="{{ $title }}">
                         <input type="hidden" name="authors" value="{{ $authors === 'Autor desconocido' ? '' : $authors }}">
@@ -71,7 +90,7 @@
                 @endauth
             </div>
 
-            @if($error)
+            @if($error ?? false)
                 <div class="alert alert-warning mt-4">{{ $error }}</div>
             @endif
         </div>

--- a/resources/views/books/show.blade.php
+++ b/resources/views/books/show.blade.php
@@ -8,14 +8,23 @@
     $title = $v['title'] ?? 'Sin título';
     $authors = isset($v['authors']) ? implode(', ', $v['authors']) : 'Autor desconocido';
     $thumb = $v['imageLinks']['thumbnail'] ?? null;
-    $desc = $v['description'] ?? null; // a veces viene con HTML
+    $desc = $v['description'] ?? null;
     $published = $v['publishedDate'] ?? '—';
     $pages = $v['pageCount'] ?? null;
     $cats = isset($v['categories']) ? implode(' · ', $v['categories']) : null;
     $avg = $v['averageRating'] ?? null;
+    $volumeId = $book['id'] ?? null;
 @endphp
 
 <div class="container">
+    {{-- Mensajes flash --}}
+    @if(session('success'))
+        <div class="alert alert-success mb-4">{{ session('success') }}</div>
+    @endif
+    @if(session('error'))
+        <div class="alert alert-warning mb-4">{{ session('error') }}</div>
+    @endif
+
     <a href="{{ route('books.index') }}" class="text-sm text-blue-600">&larr; Volver a la búsqueda</a>
 
     <div class="mt-4 grid grid-cols-1 md:grid-cols-3 gap-6">
@@ -43,14 +52,23 @@
                 {!! $desc ?? '<em>Sin descripción.</em>' !!}
             </div>
 
-            {{-- Hook para el siguiente bloque (Logs de lectura) --}}
+            {{-- Guardar en mis lecturas --}}
             <div class="mt-6">
-                <form method="POST" action="#" onsubmit="return false;">
-                    @csrf
-                    <button class="btn" disabled title="Se activará en el siguiente bloque">
-                        Guardar en mis lecturas
-                    </button>
-                </form>
+                @auth
+                    <form method="POST" action="{{ route('reading-logs.store') }}">
+                        @csrf
+                        {{-- Guardar con estado "want" por defecto --}}
+                        <input type="hidden" name="volume_id" value="{{ $volumeId }}">
+                        <input type="hidden" name="title" value="{{ $title }}">
+                        <input type="hidden" name="authors" value="{{ $authors === 'Autor desconocido' ? '' : $authors }}">
+                        <input type="hidden" name="thumbnail_url" value="{{ $thumb }}">
+                        <input type="hidden" name="status" value="want">
+
+                        <button class="btn">Guardar en mis lecturas</button>
+                    </form>
+                @else
+                    <a class="btn" href="{{ route('login') }}">Inicia sesión para guardar</a>
+                @endauth
             </div>
 
             @if($error)

--- a/resources/views/reading-logs/index.blade.php
+++ b/resources/views/reading-logs/index.blade.php
@@ -1,0 +1,42 @@
+@extends('layouts.app')
+
+@section('title', 'Mis lecturas')
+
+@section('content')
+<div class="container">
+    <h1 class="mb-4">Mis lecturas</h1>
+
+    @if($logs->isEmpty())
+        <p>Todavía no has guardado ningún libro.</p>
+        <a class="btn mt-2" href="{{ route('books.index') }}">Buscar libros</a>
+    @else
+        <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+            @foreach($logs as $log)
+                <a href="{{ route('books.show', $log->volume_id) }}" class="card block">
+                    <div class="aspect-[3/4] bg-gray-100 flex items-center justify-center overflow-hidden">
+                        @if($log->thumbnail_url)
+                            <img src="{{ $log->thumbnail_url }}" alt="{{ $log->title }}" class="w-full h-full object-cover">
+                        @else
+                            <span class="text-xs text-gray-500">Sin portada</span>
+                        @endif
+                    </div>
+                    <div class="p-2">
+                        <h3 class="font-semibold text-sm line-clamp-2">{{ $log->title }}</h3>
+                        @if($log->authors)
+                            <p class="text-xs text-gray-600 line-clamp-1">{{ $log->authors }}</p>
+                        @endif
+                        <p class="text-xs mt-1">
+                            Estado: <span class="font-medium">{{ $log->status }}</span>
+                            @if(!is_null($log->rating)) · ⭐ {{ $log->rating }}/10 @endif
+                        </p>
+                    </div>
+                </a>
+            @endforeach
+        </div>
+
+        <div class="mt-4">
+            {{ $logs->links() }}
+        </div>
+    @endif
+</div>
+@endsection

--- a/resources/views/reading-logs/index.blade.php
+++ b/resources/views/reading-logs/index.blade.php
@@ -18,36 +18,54 @@
         <p>Todavía no has guardado ningún libro.</p>
         <a class="btn mt-2" href="{{ route('books.index') }}">Buscar libros</a>
     @else
-        <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+        {{-- Grid de tarjetas --}}
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             @foreach($logs as $log)
-                <div class="card">
-                    <a href="{{ route('books.show', $log->volume_id) }}" class="block">
-                        <div class="aspect-[3/4] bg-gray-100 flex items-center justify-center overflow-hidden">
-                            @if($log->thumbnail_url)
-                                <img src="{{ $log->thumbnail_url }}" alt="{{ $log->title }}" class="w-full h-full object-cover">
-                            @else
-                                <span class="text-xs text-gray-500">Sin portada</span>
-                            @endif
-                        </div>
-                        <div class="p-2">
-                            <h3 class="font-semibold text-sm line-clamp-2">{{ $log->title }}</h3>
-                            @if($log->authors)
-                                <p class="text-xs text-gray-600 line-clamp-1">{{ $log->authors }}</p>
-                            @endif
-                            <p class="text-xs mt-1">
-                                Estado: <span class="font-medium">{{ $log->status }}</span>
-                                @if(!is_null($log->rating)) · ⭐ {{ $log->rating }}/10 @endif
-                            </p>
-                        </div>
-                    </a>
+                @php
+                    // Mejora de calidad para portadas de Google Books (usa zoom alto si viene mini)
+                    $upgrade = $upgrade ?? function (?string $url, int $zoom = 4) {
+                        if (!$url) return $url;
+                        if (str_contains($url, 'zoom=')) {
+                            return preg_replace('/zoom=\d+/', 'zoom='.$zoom, $url);
+                        }
+                        if (str_contains($url, 'books.google')) {
+                            return $url.(str_contains($url, '?') ? '&' : '?').'zoom='.$zoom;
+                        }
+                        return $url;
+                    };
+                    $cover = $upgrade($log->thumbnail_url, 4);
+                @endphp
 
-                    {{-- Form para cambiar el estado del libro --}}
-                    <div class="p-2 pt-0">
+                <div class="card">
+                    {{-- Portada --}}
+                    <div class="card-thumb aspect-[3/4] bg-gray-100 overflow-hidden">
+                        @if($cover)
+                            <img src="{{ $cover }}" alt="{{ $log->title }}">
+                        @else
+                            <div class="thumb-placeholder">Sin portada</div>
+                        @endif
+                    </div>
+
+                    {{-- Contenido --}}
+                    <div class="card-body">
+                        <a class="block" href="{{ route('books.show', $log->volume_id) }}">
+                            <h3 class="title line-clamp-2">{{ $log->title }}</h3>
+                        </a>
+                        @if($log->authors)
+                            <p class="muted line-clamp-1">{{ $log->authors }}</p>
+                        @endif
+
+                        <p class="meta">
+                            Estado: <span class="badge">{{ $log->status }}</span>
+                            @if(!is_null($log->rating)) · ⭐ {{ $log->rating }}/10 @endif
+                        </p>
+
+                        {{-- Cambiar estado --}}
                         <form method="POST" action="{{ route('reading-logs.update', $log) }}" class="mt-2">
                             @csrf
                             @method('PATCH')
-                            <label class="text-xs block mb-1">Cambiar estado:</label>
-                            <div class="flex items-center gap-2">
+                            <label class="label">Cambiar estado:</label>
+                            <div class="status-row">
                                 <select name="status" class="input">
                                     <option value="want"    @selected($log->status === 'want')>want</option>
                                     <option value="reading" @selected($log->status === 'reading')>reading</option>
@@ -55,6 +73,29 @@
                                     <option value="dropped" @selected($log->status === 'dropped')>dropped</option>
                                 </select>
                                 <button class="btn">Actualizar</button>
+                            </div>
+                        </form>
+
+                        {{-- Rating (5 estrellas con medias → envia 1..10) --}}
+                        <form method="POST" action="{{ route('reading-logs.rating', $log) }}" class="mt-3">
+                            @csrf
+                            @method('PATCH')
+                            <label class="label">Rating</label>
+
+                            <div class="stars" data-initial="{{ (int)($log->rating ?? 0) }}">
+                                <input type="hidden" name="rating" value="{{ (int)($log->rating ?? 0) }}">
+                                <div class="stars__display" aria-hidden="true">★★★★★</div>
+                                <div class="stars__fill" style="--p: {{ (($log->rating ?? 0) * 10) }}%;" aria-hidden="true">★★★★★</div>
+                                <div class="stars__hit">
+                                    @for($i = 1; $i <= 10; $i++)
+                                        <button type="button" data-v="{{ $i }}" aria-label="{{ number_format($i/2,1) }} estrellas"></button>
+                                    @endfor
+                                </div>
+                            </div>
+
+                            <div class="form-actions mt-2">
+                                <button class="btn">Guardar rating</button>
+                                <button class="btn btn-outline" name="rating" value="">Quitar rating</button>
                             </div>
                         </form>
                     </div>
@@ -67,4 +108,32 @@
         </div>
     @endif
 </div>
+
+{{-- Script del widget de estrellas (una sola vez en la página) --}}
+<script>
+document.querySelectorAll('.stars').forEach(stars => {
+  const input = stars.querySelector('input[name="rating"]');
+  const fill  = stars.querySelector('.stars__fill');
+  const hit   = stars.querySelector('.stars__hit');
+  let current = parseInt(input.value || 0, 10) || 0;
+
+  const set = v => {
+    current = v || 0;
+    input.value = current || '';
+    fill.style.setProperty('--p', (current * 10) + '%');
+  };
+
+  hit.addEventListener('mousemove', e => {
+    const v = parseInt(e.target.dataset.v || 0, 10);
+    if (v) fill.style.setProperty('--p', (v * 10) + '%');
+  });
+  hit.addEventListener('mouseleave', () => {
+    fill.style.setProperty('--p', (current * 10) + '%');
+  });
+  hit.addEventListener('click', e => {
+    const v = parseInt(e.target.dataset.v || 0, 10);
+    if (v) set(v);
+  });
+});
+</script>
 @endsection

--- a/resources/views/reading-logs/index.blade.php
+++ b/resources/views/reading-logs/index.blade.php
@@ -6,31 +6,59 @@
 <div class="container">
     <h1 class="mb-4">Mis lecturas</h1>
 
+    {{-- Mensajes flash --}}
+    @if(session('success'))
+        <div class="alert alert-success mb-4">{{ session('success') }}</div>
+    @endif
+    @if(session('error'))
+        <div class="alert alert-warning mb-4">{{ session('error') }}</div>
+    @endif
+
     @if($logs->isEmpty())
         <p>Todavía no has guardado ningún libro.</p>
         <a class="btn mt-2" href="{{ route('books.index') }}">Buscar libros</a>
     @else
         <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
             @foreach($logs as $log)
-                <a href="{{ route('books.show', $log->volume_id) }}" class="card block">
-                    <div class="aspect-[3/4] bg-gray-100 flex items-center justify-center overflow-hidden">
-                        @if($log->thumbnail_url)
-                            <img src="{{ $log->thumbnail_url }}" alt="{{ $log->title }}" class="w-full h-full object-cover">
-                        @else
-                            <span class="text-xs text-gray-500">Sin portada</span>
-                        @endif
+                <div class="card">
+                    <a href="{{ route('books.show', $log->volume_id) }}" class="block">
+                        <div class="aspect-[3/4] bg-gray-100 flex items-center justify-center overflow-hidden">
+                            @if($log->thumbnail_url)
+                                <img src="{{ $log->thumbnail_url }}" alt="{{ $log->title }}" class="w-full h-full object-cover">
+                            @else
+                                <span class="text-xs text-gray-500">Sin portada</span>
+                            @endif
+                        </div>
+                        <div class="p-2">
+                            <h3 class="font-semibold text-sm line-clamp-2">{{ $log->title }}</h3>
+                            @if($log->authors)
+                                <p class="text-xs text-gray-600 line-clamp-1">{{ $log->authors }}</p>
+                            @endif
+                            <p class="text-xs mt-1">
+                                Estado: <span class="font-medium">{{ $log->status }}</span>
+                                @if(!is_null($log->rating)) · ⭐ {{ $log->rating }}/10 @endif
+                            </p>
+                        </div>
+                    </a>
+
+                    {{-- Form para cambiar el estado del libro --}}
+                    <div class="p-2 pt-0">
+                        <form method="POST" action="{{ route('reading-logs.update', $log) }}" class="mt-2">
+                            @csrf
+                            @method('PATCH')
+                            <label class="text-xs block mb-1">Cambiar estado:</label>
+                            <div class="flex items-center gap-2">
+                                <select name="status" class="input">
+                                    <option value="want"    @selected($log->status === 'want')>want</option>
+                                    <option value="reading" @selected($log->status === 'reading')>reading</option>
+                                    <option value="read"    @selected($log->status === 'read')>read</option>
+                                    <option value="dropped" @selected($log->status === 'dropped')>dropped</option>
+                                </select>
+                                <button class="btn">Actualizar</button>
+                            </div>
+                        </form>
                     </div>
-                    <div class="p-2">
-                        <h3 class="font-semibold text-sm line-clamp-2">{{ $log->title }}</h3>
-                        @if($log->authors)
-                            <p class="text-xs text-gray-600 line-clamp-1">{{ $log->authors }}</p>
-                        @endif
-                        <p class="text-xs mt-1">
-                            Estado: <span class="font-medium">{{ $log->status }}</span>
-                            @if(!is_null($log->rating)) · ⭐ {{ $log->rating }}/10 @endif
-                        </p>
-                    </div>
-                </a>
+                </div>
             @endforeach
         </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Auth\LoginController;
 use App\Http\Controllers\Auth\RegisterController;
 use App\Http\Controllers\BookController;
+use App\Http\Controllers\ReadingLogController;
 
 // Home
 Route::get('/', function () {
@@ -47,4 +48,10 @@ Route::get('/books/{id}', [BookController::class, 'show'])->name('books.show'); 
 Route::middleware('throttle:30,1')->group(function () { // 30 solicitudes por minuto y por IP SOLO para /books.
     Route::get('/books', [BookController::class, 'index'])->name('books.index');
     Route::get('/books/{id}', [BookController::class, 'show'])->name('books.show');
+});
+
+// Rutas de logs de lectura (solo para usuarios autenticados)
+Route::middleware('auth')->group(function () {
+    Route::post('/reading-logs', [ReadingLogController::class, 'store'])
+        ->name('reading-logs.store');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -57,4 +57,7 @@ Route::middleware('auth')->group(function () {
     Route::get('/reading-logs',  [ReadingLogController::class, 'index'])->name('reading-logs.index'); // listado
     Route::patch('/reading-logs/{readingLog}', [ReadingLogController::class, 'update'])
     ->name('reading-logs.update'); // cambiar estado
+    Route::patch('/reading-logs/{readingLog}/rating', [ReadingLogController::class, 'updateRating'])
+    ->name('reading-logs.rating'); // rating
+
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Auth\RegisterController;
 use App\Http\Controllers\BookController;
 use App\Http\Controllers\ReadingLogController;
 
+
 // Home
 Route::get('/', function () {
     return view('welcome');
@@ -54,4 +55,6 @@ Route::middleware('throttle:30,1')->group(function () { // 30 solicitudes por mi
 Route::middleware('auth')->group(function () {
     Route::post('/reading-logs', [ReadingLogController::class, 'store'])->name('reading-logs.store');
     Route::get('/reading-logs',  [ReadingLogController::class, 'index'])->name('reading-logs.index'); // listado
+    Route::patch('/reading-logs/{readingLog}', [ReadingLogController::class, 'update'])
+    ->name('reading-logs.update'); // cambiar estado
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -52,6 +52,6 @@ Route::middleware('throttle:30,1')->group(function () { // 30 solicitudes por mi
 
 // Rutas de logs de lectura (solo para usuarios autenticados)
 Route::middleware('auth')->group(function () {
-    Route::post('/reading-logs', [ReadingLogController::class, 'store'])
-        ->name('reading-logs.store');
+    Route::post('/reading-logs', [ReadingLogController::class, 'store'])->name('reading-logs.store');
+    Route::get('/reading-logs',  [ReadingLogController::class, 'index'])->name('reading-logs.index'); // listado
 });


### PR DESCRIPTION
### Resumen
Bloque **Reading Logs + Books UI**. Se añade rating (5★ con medias), se limpia el layout del listado de lecturas, se mejora la calidad de portadas y se compacta el grid de búsqueda. Incluye pequeñas utilidades SCSS y alerts con buen contraste.

### Cambios principales
- **Reading logs**
  - `PATCH /reading-logs/{readingLog}/rating` (`updateRating` en `ReadingLogController`).
  - Vista `reading-logs/index.blade.php` con:
    - Portadas nítidas (Google Books `imageLinks` + `zoom=4`).
    - Selector de **estado** sin desbordes (fila `status-row`).
    - **Rating 5★ con medias** (envía 1..10) sin JS pesado.
    - Spacing limpio y acciones agrupadas.
  - SCSS: componente de estrellas, alerts accesibles, utilidades (`status-row`, `form-actions`, `line-clamp`, etc.).

- **Books**
  - `books/index.blade.php`: **grid compacto** (`results-grid`) con `auto-fill/minmax`.
  - `books/show.blade.php`: elección de la mejor imagen (`extraLarge → large → …`) y **upgrade de zoom** para mayor nitidez.
  - Unificación de estilos de card/portada con el resto del sitio.

### Configuración / build
```bash
ddev composer dump-autoload
ddev php artisan view:clear
npm run dev
```

### Cómo probar
1) **Búsqueda** (`/books`):
   - Ver grid de tarjetas compacto.
   - Abrir una ficha y comprobar portada nítida.

2) **Mis lecturas** (`/reading-logs`):
   - Cambiar **estado** y ver el flash con buen contraste.
   - Cambiar **rating** con medias estrellas y guardar; limpiar rating con el botón “Quitar”.
   - Ver portadas con nitidez (zoom 4). Si alguna quedó pequeña, volver a guardar ese libro desde su ficha para refrescar la URL.

### Notas
- El backend sigue almacenando `rating` como `TINYINT` `1–10` (`null` = sin rating).
- Si alguna portada sigue en baja resolución, el volumen no expone tamaños grandes; el `zoom` ayuda pero no hace milagros.
